### PR TITLE
update apply.first to be much more strict

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -15,7 +15,6 @@ module.exports = {
         var _value = funs[i].apply(this, args)
         if (_value !== undefined) return _value
       }
-      return _value
     }
   },
   map: function (funs) {

--- a/apply.js
+++ b/apply.js
@@ -13,8 +13,9 @@ module.exports = {
       var args = [].slice.call(arguments)
       for (var i = 0; i < funs.length; i++) {
         var _value = funs[i].apply(this, args)
-        if (_value) return _value
+        if (_value !== undefined) return _value
       }
+      return _value
     }
   },
   map: function (funs) {

--- a/test/index.js
+++ b/test/index.js
@@ -277,6 +277,27 @@ test('a module can need multiple imports', function (t) {
   t.end()
 })
 
+test('a needed module can return 0', function (t) {
+  t.plan(2)
+
+  const decrement = {
+    gives: 'decrement',
+    create: () => i => i - 1
+  }
+
+  const decrementOne = {
+    gives: 'decrementOne',
+    needs: {decrement: 'first'},
+    create: api => () => api.decrement(1)
+  }
+
+  const sockets = Combine([decrement, decrementOne])
+
+  t.equal(sockets.decrement[0](1), 0, 'decrement returns zero')
+  t.equal(sockets.decrementOne[0](), 0, 'decrementOne returns zero')
+  t.end()
+})
+
 test('throws an error when a needed module is not given', function (t) {
   const a = {
     needs: {ideas: 'first'},

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,7 @@ test('when a module needs the first of dependencies it receives the first module
   }
   const b = {
     gives: 'ideas',
-    create: () => () => null
+    create: () => () => {}
   }
   const c = {
     gives: 'ideas',


### PR DESCRIPTION
only skip over a module if it returns `undefined`. if it returns anything else (including `false` or `null`, then it will be returned).

~~also, if no module is returned but modules exist, return the last module. this case is when the default (last module) should be undefined.~~

---

the use case is i'm writing a depject module to wrap [`pino`](https://github.com/pinojs/pino/blob/master/docs/API.md#pinooptions-stream) and want to set default plugs for the setup options which can be overridden by higher priority modules, where these setup options can be falsy or you might want to reset back to null. will link to the module when it's up.