### PR TITLE
support passing in a single module to combine

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,10 +104,10 @@ function getNeeded (needs, combined) {
 
 function eachModule (obj, iter, path) {
   path = path || []
+  if (isModule(obj)) iter(obj, path.concat(k))
   for (var k in obj) {
     if (isObject(obj[k])) {
-      if (isModule(obj[k])) iter(obj[k], path.concat(k))
-      else eachModule(obj[k], iter, path.concat(k))
+      eachModule(obj[k], iter, path.concat(k))
     }
   }
 }

--- a/is.js
+++ b/is.js
@@ -21,7 +21,7 @@ function isNeeds (n) {
 }
 
 function isModule (m) {
-  return isFunction(m.create) && isGives(m.gives) && (!m.needs || isNeeds(m.needs))
+  return m && isFunction(m.create) && isGives(m.gives) && (!m.needs || isNeeds(m.needs))
 }
 
 function isString (s) {

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ test('combine two modules', function (t) {
   t.end()
 })
 
-test('combine takes an array of modules and throws if not an array', function (t) {
+test('combine can take a single module', function (t) {
   t.plan(1)
 
   const cats = {
@@ -55,7 +55,10 @@ test('combine takes an array of modules and throws if not an array', function (t
     }
   }
 
-  t.throws(() => Combine(cats))
+  const sockets = Combine(cats)
+
+  t.ok(sockets.cats, 'Combine returns an object with keys that match the keys given by all the modules')
+  t.end()
 })
 
 test('one module depends on a module that depends on another', function (t) {


### PR DESCRIPTION
before, combine expected each argument to be either an array or a nested object of modules.

after, combine supports an argument to be a single module object.