### PR TITLE
export `getNeeded` as `depject/entry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ const api = combine(modules)
 
 ### design questions
 
-Should `combine` have a way to specify the public interface?
-
 Should there be a way to create a routed plugin?
 i.e. check a field and call a specific plugin directly?
 

--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,13 @@
+var N = require('libnested')
+
+var apply = require('./apply')
+
+module.exports = function entry (sockets, needs) {
+  return N.map(needs, function (type, path) {
+    var dependency = N.get(sockets, path)
+    if (!dependency) {
+      dependency = N.set(sockets, path, [])
+    }
+    return apply[type](dependency)
+  })
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var N = require('libnested')
 
 var isModule = require('./is')
-var apply = require('./apply')
 var assertGiven = require('./assertGiven')
+var getNeeded = require('./entry')
 
 module.exports = function combine () {
   var nestedModules = Array.prototype.slice.call(arguments)
@@ -14,7 +14,7 @@ module.exports = function combine () {
 
   for (var key in modules) {
     var module = modules[key]
-    var needed = getNeeded(module.needs, combinedModules)
+    var needed = getNeeded(combinedModules, module.needs)
     var given = module.create(needed)
 
     assertGiven(module.gives, given, key)
@@ -90,16 +90,6 @@ function addGivenToCombined (given, combined, module) {
       append(combined, path, fun)
     })
   }
-}
-
-function getNeeded (needs, combined) {
-  return N.map(needs, function (type, path) {
-    var dependency = N.get(combined, path)
-    if (!dependency) {
-      dependency = N.set(combined, path, [])
-    }
-    return apply[type](dependency)
-  })
 }
 
 function eachModule (obj, iter, path) {


### PR DESCRIPTION
change arguments to `(sockets, needs) => api`

use case is so [this](https://github.com/ssbc/patchbay/blob/822d7aba3e5e907a98c48a9abe3223cc278c6c95/index.js#L9)

```js
var sockets = combine(modules)
sockets.app[0]()
```

can instead be

```js
var sockets = combine(modules)
var api = entry(sockets, { app: 'first' })
api.app()
```

this (maybe) fixes the design question

> Should `combine` have a way to specify the public interface?