### PR TITLE
add second argument `context` to reduce function shape

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -1,9 +1,9 @@
 module.exports = {
   reduce: function (funs) {
-    return function (value) {
+    return function (value, context) {
       if (!funs.length) throw new Error('depject.reduce: no functions available to reduce')
       return funs.reduce(function (value, fn) {
-        return fn(value)
+        return fn(value, context)
       }, value)
     }
   },


### PR DESCRIPTION
so the signature of a plug using 'apply.reduce' is now:

```js
(value, context) => nextValue
```

with `context` being passed in to the top function call.

related to: https://github.com/bendrucker/value-pipe/pull/2

---

use case: we want a `message_decorate` plug, where we make changes to the message element rendered, such as adding event listeners etc. while the value being passed through the reduce is the html element, each function needs to also access information from the message being rendered.

```js
var element = render(message)
var decorated = decorate(element, message)
```