### PR TITLE
better error message when a function is unavailable

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -1,15 +1,18 @@
+function toErrorMessage (type, path) {
+  return 'depject/' + type + ': no functions available at:' + path
+}
 module.exports = {
-  reduce: function (funs) {
+  reduce: function (funs, path) {
     return function (value) {
-      if (!funs.length) throw new Error('depject.reduce: no functions available to reduce')
+      if (!funs.length) throw new Error(toErrorMessage('reduce', path))
       return funs.reduce(function (value, fn) {
         return fn(value)
       }, value)
     }
   },
-  first: function (funs) {
+  first: function (funs, path) {
     return function (value) {
-      if (!funs.length) throw new Error('depject.first: no functions available to take first')
+      if (!funs.length) throw new Error(toErrorMessage('first', path))
       var args = [].slice.call(arguments)
       for (var i = 0; i < funs.length; i++) {
         var _value = funs[i].apply(this, args)
@@ -17,9 +20,9 @@ module.exports = {
       }
     }
   },
-  map: function (funs) {
+  map: function (funs, path) {
     return function (value) {
-      if (!funs.length) throw new Error('depject.map: no functions available to map')
+      if (!funs.length) throw new Error(toErrorMessage('map', path))
       var args = [].slice.call(arguments)
       return funs.map(function (fn) {
         return fn.apply(this, args)
@@ -27,4 +30,3 @@ module.exports = {
     }
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function getNeeded (needs, combined) {
     if (!dependency) {
       dependency = N.set(combined, path, [])
     }
-    return apply[type](dependency)
+    return apply[type](dependency, path.join('.'))
   })
 }
 


### PR DESCRIPTION
This puts the path of the actual error message in the error, so you don't have to dig into the stacktrace to figure out what type of thing was missing.

looks like this:

`drain.js:22 Uncaught Error: depject/first: no functions available at:sbot.pull.log`