### PR TITLE
catch stupid entry.js typos

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -8,6 +8,8 @@ module.exports = function entry (sockets, needs) {
     if (!dependency) {
       dependency = N.set(sockets, path, [])
     }
+    
+    if (!apply[type]) throw new Error(`depeject#entry: typo "${type}", choose one of: first | map | reduce`)
     return apply[type](dependency, path.join('.'))
   })
 }


### PR DESCRIPTION
I just wasted 30 minutes because I couldn't spot the difference between `first` and `frist` .. and I didn't understand the error message I was getting